### PR TITLE
Add GitHub workflow to automatically update index.yaml

### DIFF
--- a/.github/clean-index-patch.sh
+++ b/.github/clean-index-patch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sed -i -nre '/^-\s*created:/{h;n;/^[+]\s*created:/{x;p;s/^-/+/;be};x;p;x;:e};p' "$1"
+cat "$1"

--- a/.github/update-index.sh
+++ b/.github/update-index.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+info() {
+	printf '\n## %s\n' "$*"
+}
+
+raw_diff() {
+	git diff -U0 "$@" -- index.yaml | sed -re '0,/^@@ /d; /^@@ /d'
+}
+
+is_updated() {
+	raw_diff --word-diff HEAD | grep -Pqv '^(generated|\s+created):'
+}
+
+info 'Updating index...'
+git reset HEAD
+helm repo index .
+
+if ! is_updated; then
+	info 'No changes detected.'
+	exit 0
+fi
+
+info 'Commit index changes...'
+GIT_EDITOR=.github/clean-index-patch.sh git add -e index.yaml
+git commit -m "Update Helm chart index"
+
+info 'Committed index changes:'
+git show HEAD
+
+info 'Checking update correctness...'
+# the commit should not contain any removed lines except of generated field
+if raw_diff 'HEAD~1..HEAD' | grep -Pq '^-(?!generated:)'; then
+	info 'Abort due to unexpectedly removed lines from the updated index.'
+	git diff 'HEAD~1..HEAD' -- index.yaml
+	exit 1
+fi
+# the update should make result in any committable changes
+helm repo index .
+if is_updated; then
+	info 'Abort due to missing changes in the updated index.'
+	git diff HEAD -- index.yaml
+	exit 1
+fi
+
+
+if [[ -n ${GITHUB_REF_NAME:-} ]]; then
+	info 'Pushing changes...'
+	git push origin "HEAD:$GITHUB_REF_NAME"
+fi
+
+info 'Done.'
+exit 0

--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -1,0 +1,33 @@
+name: Update Index
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - repo
+    paths:
+      - "**.tgz"
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure git
+        run: |
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config --local user.name 'github-actions[bot]'
+          git config --local core.editor '.github/clean-diff.sh'
+
+      - name: Install helm
+        uses: azure/setup-helm@v3
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Update index
+        run: |
+          .github/update-index.sh


### PR DESCRIPTION
The workflow is automatically triggered on push to the repo branch, but only if some Helm chart (tgz) file is changed.

The job will fail if an existing Helm chart is changed, or the index update looks suspicious. In such cases, the update should be made locally using .github/update-index.sh script.